### PR TITLE
Pequenas mudanças para o Inception of Things

### DIFF
--- a/cmd/inspektor/main.go
+++ b/cmd/inspektor/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log"
 
-	"github.com/AdrianWR/inspektor/internal/http"
+	"inspektor/internal/http"
 )
 
 func main() {

--- a/deployments/inspektor-ingress.yaml
+++ b/deployments/inspektor-ingress.yaml
@@ -1,25 +1,14 @@
-apiVersion: traefik.containo.us/v1alpha1
-kind: Middleware
-metadata:
-  name: inspektor-middleware
-  namespace: dev
-spec:
-  stripPrefix:
-    prefixes:
-      - /inspektor
----
+
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: inspektor-ingress
   namespace: dev
-  annotations:
-    traefik.ingress.kubernetes.io/router.middlewares: dev-inspektor-middleware@kubernetescrd
 spec:
   rules:
     - http:
         paths:
-          - path: /inspektor
+          - path: /
             pathType: Prefix
             backend:
               service:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/AdrianWR/inspektor
+module inspektor
 
 go 1.21.4
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module inspektor
 
-go 1.21.4
+go 1.21
 
 require (
 	github.com/gorilla/mux v1.8.1

--- a/internal/http/handlers/get.go
+++ b/internal/http/handlers/get.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"net/http"
 
-	"github.com/AdrianWR/inspektor/internal/inspection/model"
+	"inspektor/internal/inspection/model"
 )
 
 func (s service) Get() http.HandlerFunc {

--- a/internal/http/handlers/handlers.go
+++ b/internal/http/handlers/handlers.go
@@ -1,7 +1,7 @@
 package handlers
 
 import (
-	inspectionService "github.com/AdrianWR/inspektor/internal/inspection/service"
+	inspectionService "inspektor/internal/inspection/service"
 	"go.uber.org/zap"
 )
 

--- a/internal/http/handlers/helpers.go
+++ b/internal/http/handlers/helpers.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"net/http"
 
-	erro "github.com/AdrianWR/inspektor/pkg/errors"
+	erro "inspektor/pkg/errors"
 )
 
 func (s service) respond(w http.ResponseWriter, data interface{}, status int) {

--- a/internal/http/routes.go
+++ b/internal/http/routes.go
@@ -3,13 +3,16 @@ package http
 import (
 	"net/http"
 
-	"github.com/AdrianWR/inspektor/internal/http/handlers"
+	"inspektor/internal/http/handlers"
 	"github.com/gorilla/mux"
 	"go.uber.org/zap"
 )
 
 func RegisterRoutes(r *mux.Router, lg *zap.SugaredLogger) {
 	handler := handlers.NewHandler(lg)
+
+	// register root route am calll inspect
+    r.HandleFunc("/", handler.Get()).Methods(http.MethodGet)
 
 	s := r.PathPrefix("/v1").Subrouter()
 	s.HandleFunc("/healthz", handler.Health()).Methods(http.MethodGet)

--- a/internal/http/routes.go
+++ b/internal/http/routes.go
@@ -11,7 +11,7 @@ import (
 func RegisterRoutes(r *mux.Router, lg *zap.SugaredLogger) {
 	handler := handlers.NewHandler(lg)
 
-	// register root route am calll inspect
+	// register root route to call inspect
     r.HandleFunc("/", handler.Get()).Methods(http.MethodGet)
 
 	s := r.PathPrefix("/v1").Subrouter()

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -13,7 +13,7 @@ import (
 	"github.com/rs/cors"
 	"go.uber.org/zap"
 
-	"github.com/AdrianWR/inspektor/internal/config"
+	"inspektor/internal/config"
 )
 
 type Server struct {

--- a/internal/inspection/service/get.go
+++ b/internal/inspection/service/get.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/AdrianWR/inspektor/internal/inspection/model"
+	"inspektor/internal/inspection/model"
 )
 
 func getPodName() string {


### PR DESCRIPTION
mudei o module name de github.com/AdrianWR/inspektor para apenas inspektor.
Facilita quando testo no gitlab.

Criei uma rota root ('/') para se adequar ao exemplo do subject:

```bash
$> curl http://localhost:8888/
{"status":"ok", "message": "v2"}
```

pequena mudança na versão do Go (para se ajustar ao worker do gitlab quando rodar as tasks)